### PR TITLE
Add version to the require command

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -10,7 +10,7 @@ following command to download the latest stable version of this bundle:
 
 .. code-block:: bash
 
-    $ composer require 'pierrerolland/imagick-bundle'
+    $ composer require pierrerolland/imagick-bundle:dev-master
 
 This command requires you to have Composer installed globally, as explained
 in the `installation chapter`_ of the Composer documentation.


### PR DESCRIPTION
If do not define dev-master version, an exception is thrown : 
"Could not find package pierrerolland/imagick-bundle at any version for your minimum-stability (stable)"
